### PR TITLE
Fix RoundHalfUp and add RoundHalfDown and RoundHalfEven

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,8 @@
   there was unexpected behavior on negative numbers.
 * Addition of `scaleUp` and `scaleUpBounded`
 * Addition of `toFixed`, `fromFixed` and `fromFixedBounded`
+* Fix `RoundHalfUp` algorithm
+* Addition of `RoundHalfDown` and `RoundHalfEven`
 
 ## 0.1.0
 

--- a/src/Numeric/Decimal.hs
+++ b/src/Numeric/Decimal.hs
@@ -11,6 +11,8 @@ module Numeric.Decimal
   -- * Rounding
   -- ** Round half up
   , RoundHalfUp
+  -- ** Round half down
+  , RoundHalfDown
   -- ** Round down
   , RoundDown
   , Floor
@@ -57,14 +59,26 @@ type Decimal64 s = Decimal RoundHalfUp s Int64
 -- rounding strategy:
 --
 -- >>> :set -XDataKinds
--- >>> roundDecimal <$> (3.65 :: IO (Decimal RoundHalfUp 2 Int)) :: IO (Decimal RoundHalfUp 1 Int)
+-- >>> roundDecimal <$> (3.740 :: IO (Decimal RoundHalfUp 3 Int)) :: IO (Decimal RoundHalfUp 1 Int)
 -- 3.7
--- >>> roundDecimal <$> (3.75 :: IO (Decimal RoundHalfUp 2 Int)) :: IO (Decimal RoundHalfUp 1 Int)
+-- >>> roundDecimal <$> (3.749 :: IO (Decimal RoundHalfUp 3 Int)) :: IO (Decimal RoundHalfUp 1 Int)
+-- 3.7
+-- >>> roundDecimal <$> (3.750 :: IO (Decimal RoundHalfUp 3 Int)) :: IO (Decimal RoundHalfUp 1 Int)
 -- 3.8
--- >>> roundDecimal <$> (3.89 :: IO (Decimal RoundHalfUp 2 Int)) :: IO (Decimal RoundHalfUp 1 Int)
--- 3.9
--- >>> roundDecimal <$> (-3.65 :: IO (Decimal RoundHalfUp 2 Int)) :: IO (Decimal RoundHalfUp 1 Int)
--- -3.6
+-- >>> roundDecimal <$> (3.751 :: IO (Decimal RoundHalfUp 3 Int)) :: IO (Decimal RoundHalfUp 1 Int)
+-- 3.8
+-- >>> roundDecimal <$> (3.760 :: IO (Decimal RoundHalfUp 3 Int)) :: IO (Decimal RoundHalfUp 1 Int)
+-- 3.8
+-- >>> roundDecimal <$> (-3.740 :: IO (Decimal RoundHalfUp 3 Int)) :: IO (Decimal RoundHalfUp 1 Int)
+-- -3.7
+-- >>> roundDecimal <$> (-3.749 :: IO (Decimal RoundHalfUp 3 Int)) :: IO (Decimal RoundHalfUp 1 Int)
+-- -3.7
+-- >>> roundDecimal <$> (-3.750 :: IO (Decimal RoundHalfUp 3 Int)) :: IO (Decimal RoundHalfUp 1 Int)
+-- -3.7
+-- >>> roundDecimal <$> (-3.751 :: IO (Decimal RoundHalfUp 3 Int)) :: IO (Decimal RoundHalfUp 1 Int)
+-- -3.8
+-- >>> roundDecimal <$> (-3.760 :: IO (Decimal RoundHalfUp 3 Int)) :: IO (Decimal RoundHalfUp 1 Int)
+-- -3.8
 --
 -- @since 0.1.0
 data RoundHalfUp
@@ -105,16 +119,89 @@ instance Round RoundHalfUp Word64 where
 
 roundHalfUp :: forall r n k p . (Integral p, KnownNat k) => Decimal r (n + k) p -> Decimal r n p
 roundHalfUp (Decimal x)
-    | k == 0                    = Decimal x
-    | r >= 5                    = Decimal (q + 1)
-    | signum r < 0 && abs r > 5 = Decimal (q - 1)
-    | otherwise                 = Decimal q
+    | k == 0                     = Decimal x
+    | r >= s1                    = Decimal (q + 1)
+    | signum r < 0 && abs r > s1 = Decimal (q - 1)
+    | otherwise                  = Decimal q
     where
       k = fromIntegral (natVal (Proxy :: Proxy k)) :: Int
-      s1 = 10 ^ (k - 1)
-      (q, r) = (`quot` s1) <$> quotRem x (s1 * 10)
+      s1 = 10 ^ k
+      (q, r) = (2 *) <$> quotRem x s1
 {-# INLINABLE roundHalfUp #-}
 
+-- | [Round half down](https://en.wikipedia.org/wiki/Rounding#Round_half_down): A very common
+-- rounding strategy:
+--
+-- >>> :set -XDataKinds
+-- >>> roundDecimal <$> (3.740 :: IO (Decimal RoundHalfDown 3 Int)) :: IO (Decimal RoundHalfDown 1 Int)
+-- 3.7
+-- >>> roundDecimal <$> (3.749 :: IO (Decimal RoundHalfDown 3 Int)) :: IO (Decimal RoundHalfDown 1 Int)
+-- 3.7
+-- >>> roundDecimal <$> (3.750 :: IO (Decimal RoundHalfDown 3 Int)) :: IO (Decimal RoundHalfDown 1 Int)
+-- 3.7
+-- >>> roundDecimal <$> (3.751 :: IO (Decimal RoundHalfDown 3 Int)) :: IO (Decimal RoundHalfDown 1 Int)
+-- 3.8
+-- >>> roundDecimal <$> (3.760 :: IO (Decimal RoundHalfDown 3 Int)) :: IO (Decimal RoundHalfDown 1 Int)
+-- 3.8
+-- >>> roundDecimal <$> (-3.740 :: IO (Decimal RoundHalfDown 3 Int)) :: IO (Decimal RoundHalfDown 1 Int)
+-- -3.7
+-- >>> roundDecimal <$> (-3.749 :: IO (Decimal RoundHalfDown 3 Int)) :: IO (Decimal RoundHalfDown 1 Int)
+-- -3.7
+-- >>> roundDecimal <$> (-3.750 :: IO (Decimal RoundHalfDown 3 Int)) :: IO (Decimal RoundHalfDown 1 Int)
+-- -3.8
+-- >>> roundDecimal <$> (-3.751 :: IO (Decimal RoundHalfDown 3 Int)) :: IO (Decimal RoundHalfDown 1 Int)
+-- -3.8
+-- >>> roundDecimal <$> (-3.760 :: IO (Decimal RoundHalfDown 3 Int)) :: IO (Decimal RoundHalfDown 1 Int)
+-- -3.8
+--
+-- @since 0.1.1
+data RoundHalfDown
+
+instance Round RoundHalfDown Integer where
+  roundDecimal = roundHalfDown
+  {-# INLINABLE roundDecimal #-}
+instance Round RoundHalfDown Int where
+  roundDecimal = roundHalfDown
+  {-# INLINABLE roundDecimal #-}
+instance Round RoundHalfDown Int8 where
+  roundDecimal = roundHalfDown
+  {-# INLINABLE roundDecimal #-}
+instance Round RoundHalfDown Int16 where
+  roundDecimal = roundHalfDown
+  {-# INLINABLE roundDecimal #-}
+instance Round RoundHalfDown Int32 where
+  roundDecimal = roundHalfDown
+  {-# INLINABLE roundDecimal #-}
+instance Round RoundHalfDown Int64 where
+  roundDecimal = roundHalfDown
+  {-# INLINABLE roundDecimal #-}
+instance Round RoundHalfDown Word where
+  roundDecimal = roundHalfDown
+  {-# INLINABLE roundDecimal #-}
+instance Round RoundHalfDown Word8 where
+  roundDecimal = roundHalfDown
+  {-# INLINABLE roundDecimal #-}
+instance Round RoundHalfDown Word16 where
+  roundDecimal = roundHalfDown
+  {-# INLINABLE roundDecimal #-}
+instance Round RoundHalfDown Word32 where
+  roundDecimal = roundHalfDown
+  {-# INLINABLE roundDecimal #-}
+instance Round RoundHalfDown Word64 where
+  roundDecimal = roundHalfDown
+  {-# INLINABLE roundDecimal #-}
+
+roundHalfDown :: forall r n k p . (Integral p, KnownNat k) => Decimal r (n + k) p -> Decimal r n p
+roundHalfDown (Decimal x)
+    | k == 0                      = Decimal x
+    | r > s1                      = Decimal (q + 1)
+    | signum r < 0 && abs r >= s1 = Decimal (q - 1)
+    | otherwise                   = Decimal q
+    where
+      k = fromIntegral (natVal (Proxy :: Proxy k)) :: Int
+      s1 = 10 ^ k
+      (q, r) = (2 *) <$> quotRem x s1
+{-# INLINABLE roundHalfDown #-}
 
 -- | [Round down](https://en.wikipedia.org/wiki/Rounding#Rounding_down): Round towards minus infinity:
 --

--- a/src/Numeric/Decimal.hs
+++ b/src/Numeric/Decimal.hs
@@ -156,7 +156,7 @@ roundHalfUp (Decimal x)
 -- >>> roundDecimal <$> (-3.760 :: IO (Decimal RoundHalfDown 3 Int)) :: IO (Decimal RoundHalfDown 1 Int)
 -- -3.8
 --
--- @since 0.1.1
+-- @since 0.2.0
 data RoundHalfDown
 
 instance Round RoundHalfDown Integer where
@@ -234,7 +234,7 @@ roundHalfDown (Decimal x)
 -- >>> roundDecimal <$> (-3.760 :: IO (Decimal RoundHalfEven 3 Int)) :: IO (Decimal RoundHalfEven 1 Int)
 -- -3.8
 --
--- @since 0.1.1
+-- @since 0.2.0
 data RoundHalfEven
 
 instance Round RoundHalfEven Integer where

--- a/src/Numeric/Decimal.hs
+++ b/src/Numeric/Decimal.hs
@@ -13,6 +13,8 @@ module Numeric.Decimal
   , RoundHalfUp
   -- ** Round half down
   , RoundHalfDown
+  -- ** Round half even
+  , RoundHalfEven
   -- ** Round down
   , RoundDown
   , Floor
@@ -202,6 +204,86 @@ roundHalfDown (Decimal x)
       s1 = 10 ^ k
       (q, r) = (2 *) <$> quotRem x s1
 {-# INLINABLE roundHalfDown #-}
+
+-- | [Round half even](https://en.wikipedia.org/wiki/Rounding#Round_half_to_even): if the
+-- fractional part of x is 0.5, then y is the even integer nearest to x.
+--
+-- >>> :set -XDataKinds
+-- >>> roundDecimal <$> (3.650 :: IO (Decimal RoundHalfEven 3 Int)) :: IO (Decimal RoundHalfEven 1 Int)
+-- 3.6
+-- >>> roundDecimal <$> (3.740 :: IO (Decimal RoundHalfEven 3 Int)) :: IO (Decimal RoundHalfEven 1 Int)
+-- 3.7
+-- >>> roundDecimal <$> (3.749 :: IO (Decimal RoundHalfEven 3 Int)) :: IO (Decimal RoundHalfEven 1 Int)
+-- 3.7
+-- >>> roundDecimal <$> (3.750 :: IO (Decimal RoundHalfEven 3 Int)) :: IO (Decimal RoundHalfEven 1 Int)
+-- 3.8
+-- >>> roundDecimal <$> (3.751 :: IO (Decimal RoundHalfEven 3 Int)) :: IO (Decimal RoundHalfEven 1 Int)
+-- 3.8
+-- >>> roundDecimal <$> (3.760 :: IO (Decimal RoundHalfEven 3 Int)) :: IO (Decimal RoundHalfEven 1 Int)
+-- 3.8
+-- >>> roundDecimal <$> (-3.650 :: IO (Decimal RoundHalfEven 3 Int)) :: IO (Decimal RoundHalfEven 1 Int)
+-- -3.6
+-- >>> roundDecimal <$> (-3.740 :: IO (Decimal RoundHalfEven 3 Int)) :: IO (Decimal RoundHalfEven 1 Int)
+-- -3.7
+-- >>> roundDecimal <$> (-3.749 :: IO (Decimal RoundHalfEven 3 Int)) :: IO (Decimal RoundHalfEven 1 Int)
+-- -3.7
+-- >>> roundDecimal <$> (-3.750 :: IO (Decimal RoundHalfEven 3 Int)) :: IO (Decimal RoundHalfEven 1 Int)
+-- -3.8
+-- >>> roundDecimal <$> (-3.751 :: IO (Decimal RoundHalfEven 3 Int)) :: IO (Decimal RoundHalfEven 1 Int)
+-- -3.8
+-- >>> roundDecimal <$> (-3.760 :: IO (Decimal RoundHalfEven 3 Int)) :: IO (Decimal RoundHalfEven 1 Int)
+-- -3.8
+--
+-- @since 0.1.1
+data RoundHalfEven
+
+instance Round RoundHalfEven Integer where
+  roundDecimal = roundHalfEven
+  {-# INLINABLE roundDecimal #-}
+instance Round RoundHalfEven Int where
+  roundDecimal = roundHalfEven
+  {-# INLINABLE roundDecimal #-}
+instance Round RoundHalfEven Int8 where
+  roundDecimal = roundHalfEven
+  {-# INLINABLE roundDecimal #-}
+instance Round RoundHalfEven Int16 where
+  roundDecimal = roundHalfEven
+  {-# INLINABLE roundDecimal #-}
+instance Round RoundHalfEven Int32 where
+  roundDecimal = roundHalfEven
+  {-# INLINABLE roundDecimal #-}
+instance Round RoundHalfEven Int64 where
+  roundDecimal = roundHalfEven
+  {-# INLINABLE roundDecimal #-}
+instance Round RoundHalfEven Word where
+  roundDecimal = roundHalfEven
+  {-# INLINABLE roundDecimal #-}
+instance Round RoundHalfEven Word8 where
+  roundDecimal = roundHalfEven
+  {-# INLINABLE roundDecimal #-}
+instance Round RoundHalfEven Word16 where
+  roundDecimal = roundHalfEven
+  {-# INLINABLE roundDecimal #-}
+instance Round RoundHalfEven Word32 where
+  roundDecimal = roundHalfEven
+  {-# INLINABLE roundDecimal #-}
+instance Round RoundHalfEven Word64 where
+  roundDecimal = roundHalfEven
+  {-# INLINABLE roundDecimal #-}
+
+roundHalfEven :: forall r n k p . (Integral p, KnownNat k) => Decimal r (n + k) p -> Decimal r n p
+roundHalfEven (Decimal x)
+    | k == 0                     = Decimal x
+    | abs r == s1 && odd q       = Decimal (q + signum r)
+    | abs r == s1                = Decimal q
+    | r > s1                     = Decimal (q + 1)
+    | signum r < 0 && abs r > s1 = Decimal (q - 1)
+    | otherwise                  = Decimal q
+    where
+      k = fromIntegral (natVal (Proxy :: Proxy k)) :: Int
+      s1 = 10 ^ k
+      (q, r) = (2 *) <$> quotRem x s1
+{-# INLINABLE roundHalfEven #-}
 
 -- | [Round down](https://en.wikipedia.org/wiki/Rounding#Rounding_down): Round towards minus infinity:
 --

--- a/tests/Numeric/DecimalSpec.hs
+++ b/tests/Numeric/DecimalSpec.hs
@@ -170,6 +170,7 @@ specBouned ::
      , Bounded a
      , NFData a
      , Round RoundHalfUp a
+     , Round RoundHalfDown a
      , Round RoundDown a
      , Round RoundToZero a
      )
@@ -231,6 +232,7 @@ specRounding ::
      , Typeable p
      , Arbitrary p
      , Round RoundHalfUp p
+     , Round RoundHalfDown p
      , Round RoundDown p
      , Round RoundToZero p
      )
@@ -239,6 +241,9 @@ specRounding = do
   prop (propNamePrefix . showsDecimalType @RoundHalfUp @(s + k) @p $ "") $
     prop_Rounding @RoundHalfUp @s @k @p
     (roundHalfUpTo (fromIntegral (natVal (Proxy :: Proxy s))))
+  prop (propNamePrefix . showsDecimalType @RoundHalfDown @(s + k) @p $ "") $
+    prop_Rounding @RoundHalfDown @s @k @p
+    (roundHalfDownTo (fromIntegral (natVal (Proxy :: Proxy s))))
   prop (propNamePrefix . showsDecimalType @RoundToZero @(s + k) @p $ "") $
     prop_Rounding @RoundToZero @s @k @p
     (roundRoundToZeroTo (fromIntegral (natVal (Proxy :: Proxy s))))
@@ -386,7 +391,13 @@ assertExceptionIO isExc action =
 
 roundHalfUpTo :: Natural -> Rational -> Rational
 roundHalfUpTo to rational =
-  floor ((truncate (rational * ((s10 * 10) % 1) + 5) :: Integer) % 10) % s10
+  floor ((rational * ((s10 * 10) % 1) + 5) * (1 % 10)) % s10
+  where
+    s10 = 10 ^ to :: Integer
+
+roundHalfDownTo :: Natural -> Rational -> Rational
+roundHalfDownTo to rational =
+  ceiling ((rational * ((s10 * 10) % 1) - 5) * (1 % 10)) % s10
   where
     s10 = 10 ^ to :: Integer
 

--- a/tests/Numeric/DecimalSpec.hs
+++ b/tests/Numeric/DecimalSpec.hs
@@ -171,6 +171,7 @@ specBouned ::
      , NFData a
      , Round RoundHalfUp a
      , Round RoundHalfDown a
+     , Round RoundHalfEven a
      , Round RoundDown a
      , Round RoundToZero a
      )
@@ -233,6 +234,7 @@ specRounding ::
      , Arbitrary p
      , Round RoundHalfUp p
      , Round RoundHalfDown p
+     , Round RoundHalfEven p
      , Round RoundDown p
      , Round RoundToZero p
      )
@@ -244,6 +246,9 @@ specRounding = do
   prop (propNamePrefix . showsDecimalType @RoundHalfDown @(s + k) @p $ "") $
     prop_Rounding @RoundHalfDown @s @k @p
     (roundHalfDownTo (fromIntegral (natVal (Proxy :: Proxy s))))
+  prop (propNamePrefix . showsDecimalType @RoundHalfEven @(s + k) @p $ "") $
+    prop_Rounding @RoundHalfEven @s @k @p
+    (roundHalfEvenTo (fromIntegral (natVal (Proxy :: Proxy s))))
   prop (propNamePrefix . showsDecimalType @RoundToZero @(s + k) @p $ "") $
     prop_Rounding @RoundToZero @s @k @p
     (roundRoundToZeroTo (fromIntegral (natVal (Proxy :: Proxy s))))
@@ -401,6 +406,10 @@ roundHalfDownTo to rational =
   where
     s10 = 10 ^ to :: Integer
 
+roundHalfEvenTo :: Natural -> Rational -> Rational
+roundHalfEvenTo to rational =
+  fromInteger (round $ rational * (10 ^ to)) / 10 ^ to
+
 roundFloorTo :: Natural -> Rational -> Rational
 roundFloorTo to rational = (floor (rational * (s10 % 1)) :: Integer) % s10
   where
@@ -424,8 +433,3 @@ _roundCommercial to rational
              then q + 1
              else q) %
           s10
-
--- Once round half even is implemented, this can be used for testing
-_roundBankerTo :: Integer -> Rational -> Rational
-_roundBankerTo to rational =
-  fromInteger (round $ rational * (10 ^ to)) / 10 ^ to


### PR DESCRIPTION
This fixes https://github.com/fpco/safe-decimal/issues/3 and implements RoundHalfDown and RoundHalfEven.

* All RoundHalf* modes handle edge cases around the half-point correctly. All have several cases in the documentation showing the behaviour for positive and negative value.
* RoundHalfUp test oracle was fixed by removing the call to truncate.

I didn't even try to benchmark and profile the solutions (because I don't really know how), so there is probably room for improvement at that front.